### PR TITLE
fix(activity): label lines

### DIFF
--- a/src/components/activity/objekt-chart.tsx
+++ b/src/components/activity/objekt-chart.tsx
@@ -20,6 +20,7 @@ export default function ObjektChart({ members }: Props) {
           dataKey="count"
           innerRadius={60}
           outerRadius={100}
+          labelLine={false}
           stroke="#1e293b"
           strokeWidth={2}
           label={({


### PR DESCRIPTION
I didn't actually pull this and run (slow internet tonight), but IIRC this should remove the default label lines sticking out:

<img width="674" alt="image" src="https://github.com/user-attachments/assets/9cce5c07-bd1b-4433-b660-d29235aa481c">