### PR TITLE
Remove duplicates from discord formatted list

### DIFF
--- a/src/components/lists/actions.ts
+++ b/src/components/lists/actions.ts
@@ -259,8 +259,10 @@ function format(collections: CollectionSubset[], entries: ObjektListEntry[]) {
   // format each member's entry
   return sortedMembers.map((member) => {
     const memberCollections = groupedCollections[member];
-    const formattedCollections = memberCollections
-      .map((c) => `${c.season.at(0)}${c.collectionNo}`)
+    const formattedCollections = [...new Set(
+        memberCollections
+          .map((c) => `${c.season.at(0)}${c.collectionNo}`)
+      )]
       .sort()
       .join(", ");
     return `${member} ${formattedCollections}`;


### PR DESCRIPTION
If you accidentally add an objekt more than once to a list, it will be added again. If you then try to generate discord formatted list, it will repeat the element as many times as you have added it, which doesn't seem ideal. This adds the values to a Set to guarantee uniqueness when the list is generated.

Unfortunately, this is a mitigation – my original idea was to use 'onConflictDoNothing' with listId/objektId as targets but I was unsure of how to then check for unsuccessful DB inserts, as it would return nothing if it was a duplicate. This also treats the cases of duplicate objekts that already exist in the DB without any direct DB modifications being required.